### PR TITLE
Fixes the crashing for GeoNode version > 4.2, where there can be multiple authors

### DIFF
--- a/src/qgis_geonode/apiclient/__init__.py
+++ b/src/qgis_geonode/apiclient/__init__.py
@@ -21,7 +21,9 @@ def get_geonode_client(
 
 
 def select_client_class_path(geonode_version: packaging_version.Version) -> str:
-    if geonode_version.major == 4:
+    if geonode_version.major == 4 and geonode_version.minor >= 2:
+        result = "qgis_geonode.apiclient.geonode_v3.GeonodeApiClientVersion_4_2_0"
+    if geonode_version.major == 4 and geonode_version.minor < 2:
         result = "qgis_geonode.apiclient.geonode_v3.GeonodeApiClientVersion_3_4_0"
     elif geonode_version.major == 3 and geonode_version.minor >= 4:
         result = "qgis_geonode.apiclient.geonode_v3.GeonodeApiClientVersion_3_4_0"

--- a/src/qgis_geonode/apiclient/geonode_v3.py
+++ b/src/qgis_geonode/apiclient/geonode_v3.py
@@ -407,6 +407,25 @@ class GeonodeApiClientVersion_3_4_0(GeonodeApiClientVersion_3_x):
         return models.Dataset(**properties)
 
 
+class GeonodeApiClientVersion_4_2_0(GeonodeApiClientVersion_3_4_0):
+
+    def _parse_dataset_detail(self, raw_dataset: typing.Dict) -> models.Dataset:
+        properties = self._get_common_model_properties(raw_dataset)
+        properties.update(
+            language=raw_dataset.get("language"),
+            license=(raw_dataset.get("license") or {}).get("identifier", ""),
+            constraints=raw_dataset.get("raw_constraints_other", ""),
+            owner=raw_dataset.get("owner", {}).get("username", ""),
+            metadata_author=[
+                author.get("username", "")
+                for author in raw_dataset.get("metadata_author", [])
+            ]
+            .join(" ")
+            .strip(),
+        )
+        return models.Dataset(**properties)
+
+
 class GeonodeApiClientVersion_3_3_0(GeonodeApiClientVersion_3_x):
     """API client for GeoNode version 3.3.x.
 


### PR DESCRIPTION
Starting with GeoNode version 4.2, there can be multiple authors and are contained within a list, even if there is single author. This breaks the handling of the dataset.

Related issue: https://github.com/GeoNode/QGISGeoNodePlugin/issues/268