### PR TITLE
Fixed encoding issues for characters with umlaut

### DIFF
--- a/src/qgis_geonode/styles.py
+++ b/src/qgis_geonode/styles.py
@@ -47,7 +47,12 @@ def serialize_sld_named_layer(sld_named_layer: QtXml.QDomElement) -> str:
     buffer_ = QtCore.QByteArray()
     stream = QtCore.QTextStream(buffer_)
     sld_named_layer.save(stream, 0)
-    return buffer_.data().decode(encoding="utf-8")
+    element_string = ""
+    try:
+        element_string = buffer_.data().decode(encoding="utf-8")
+    except UnicodeDecodeError:
+        element_string = buffer_.data().decode(encoding="latin-1")
+    return element_string
 
 
 def get_usable_sld(


### PR DESCRIPTION
The style string is being decoded as 'utf-8' from the hex encoding. Changing the decoding to 'latin-1' gets rid of the 'UnicodeDecodeError for umlaut characters.

Here is the  [related issue](https://github.com/GeoNode/QGISGeoNodePlugin/issues/248).