### PR TITLE
Fixed connection error when base url with '#' is provided as the connection url

### DIFF
--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -46,7 +46,7 @@ class BaseGeonodeClient(QtCore.QObject):
     ):
         super().__init__()
         self.auth_config = auth_config or ""
-        self.base_url = base_url.rstrip("/")
+        self.base_url = base_url.rstrip("#/")
         self.page_size = page_size
         self.wfs_version = wfs_version
         self.network_requests_timeout = network_requests_timeout

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -140,7 +140,7 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         return ConnectionSettings(
             id=self.connection_id,
             name=self.name_le.text().strip(),
-            base_url=self.url_le.text().strip().rstrip("/"),
+            base_url=self.url_le.text().strip().rstrip("#/"),
             auth_config=self.authcfg_acs.configId(),
             page_size=self.page_size_sb.value(),
             geonode_version=self.remote_geonode_version,


### PR DESCRIPTION
If a url is copied from the browser from a GeoNode instance e.g., https://stable.demo.geonode.org/#/ it contains an a hash sign at the end which fails to connect. This fixes the issue by parsing the provided url.

This PR fixes [issue 274](https://github.com/GeoNode/QGISGeoNodePlugin/issues/274).