### PR TITLE
KeyError: 'url' during layer upload to GeoNode

### DIFF
--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -33,7 +33,7 @@ class BaseGeonodeClient(QtCore.QObject):
     style_detail_error_received = QtCore.pyqtSignal([str], [str, int, str])
     keyword_list_received = QtCore.pyqtSignal(list)
     search_error_received = QtCore.pyqtSignal([str], [str, int, str])
-    dataset_uploaded = QtCore.pyqtSignal(int)
+    dataset_uploaded = QtCore.pyqtSignal()
     dataset_upload_error_received = QtCore.pyqtSignal([str], [str, int, str])
 
     def __init__(

--- a/src/qgis_geonode/apiclient/geonode_api_v2.py
+++ b/src/qgis_geonode/apiclient/geonode_api_v2.py
@@ -179,12 +179,7 @@ class GeoNodeApiClient(BaseGeonodeClient):
         if result:
             response_contents = self.network_fetcher_task.response_contents[0]
             if response_contents.http_status_code in success_statuses:
-                deserialized = network.deserialize_json_response(
-                    response_contents.response_body
-                )
-                catalogue_url = deserialized["url"]
-                dataset_pk = catalogue_url.rsplit("/")[-1]
-                self.dataset_uploaded.emit(int(dataset_pk))
+                self.dataset_uploaded.emit()
             else:
                 self.dataset_upload_error_received[str, int, str].emit(
                     response_contents.qt_error,

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -394,7 +394,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
             self.layer, allow_public_access=self.public_access_chb.isChecked()
         )
 
-    def handle_layer_uploaded(self, dataset_pk: int):
+    def handle_layer_uploaded(self):
         self._toggle_upload_controls(enabled=True)
         self._show_message("Layer uploaded successfully!")
 


### PR DESCRIPTION
This PR solves the `keyError: 'url'` which reported in the following [issue](https://github.com/GeoNode/QGISGeoNodePlugin/issues/263).