### PR TITLE
Fixing the different sizes of the thumbnails, presented after searching

### DIFF
--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -61,7 +61,7 @@
         <item>
          <widget class="QLabel" name="title_la">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -175,14 +175,14 @@
         <item>
          <widget class="QLabel" name="thumbnail_la">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>200</width>
+            <width>400</width>
             <height>200</height>
            </size>
           </property>


### PR DESCRIPTION
This PR solves the different sizes of the thumbnails after displaying the searching results.