### PR TITLE
Fix the error after the reload a default style or metadata from GeoNode

### DIFF
--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -106,7 +106,7 @@ class PluginMetadata:
         self.plugin_metadata = _plugin_metadata["general"]
 
         homepage = urllib.parse.urlparse(self.plugin_metadata.get("homepage"))
-        self.homepage_root = f"{homepage.scheme}://{homepage.hostname}"
+        self.homepage_root = f"{homepage.scheme}://{homepage.hostname}/"
         self.help_page = homepage.path.strip("/")
 
     def get(self, attr):

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -4,6 +4,7 @@ import enum
 import json
 import typing
 import uuid
+import urllib.parse
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -104,8 +105,15 @@ class PluginMetadata:
 
         self.plugin_metadata = _plugin_metadata["general"]
 
+        homepage = urllib.parse.urlparse(self.plugin_metadata.get("homepage"))
+        self.homepage_root = f"{homepage.scheme}://{homepage.hostname}"
+        self.help_page = homepage.path.strip("/")
+
     def get(self, attr):
-        return self.plugin_metadata.get(attr)
+        try:
+            return getattr(self, attr)
+        except ValueError:
+            return self.plugin_metadata.get(attr)
 
 
 class SettingsManager(QtCore.QObject):

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -73,6 +73,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
     def __init__(self, layer, canvas, parent):
         super().__init__(layer, canvas, parent)
         self.setupUi(self)
+        self.setProperty("helpPage", conf.plugin_metadata.get("help_page"))
         self.open_detail_url_pb.setIcon(
             QtGui.QIcon(":/plugins/qgis_geonode/mIconGeonode.svg")
         )

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -468,8 +468,13 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
         # self.parent().parent()...
         properties_dialog = self.find_parent_by_type(self, QtWidgets.QDialog)
 
-        # Sync GeoNode's SLD or / and metadata with the layer properties dialog
-        properties_dialog.syncToLayer()
+        if properties_dialog != None:
+            # Sync GeoNode's SLD or / and metadata with the layer properties dialog
+            properties_dialog.syncToLayer()
+        else:
+            self._show_message(
+                "The corresponding layer properties from GeoNode cannot be loaded correctly..."
+            )
 
     def _toggle_link_controls(self, enabled: bool) -> None:
         self.links_gb.setEnabled(enabled)

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -473,7 +473,8 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
             properties_dialog.syncToLayer()
         else:
             self._show_message(
-                "The corresponding layer properties from GeoNode cannot be loaded correctly..."
+                "The corresponding layer properties from GeoNode cannot be loaded correctly...",
+                level=qgis.core.Qgis.Critical,
             )
 
     def _toggle_link_controls(self, enabled: bool) -> None:

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -315,7 +315,8 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
         dataset = self.get_dataset()
         updated_metadata = populate_metadata(self.layer.metadata(), dataset)
         self.layer.setMetadata(updated_metadata)
-        self._get_layer_properties_dialog(self.layer)
+        # sync layer properties with the reloaded SLD and/or Metadata from GeoNode
+        self.sync_layer_properties()
 
     # FIXME: rather use the api_client to perform the metadata upload
     def upload_metadata(self) -> None:
@@ -433,7 +434,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
             dataset.default_style.sld, sld_load_error_msg
         )
         if sld_load_result:
-            self._get_layer_properties_dialog(self.layer)
+            self.sync_layer_properties()
         else:
             self._show_message(
                 message=f"Could not load GeoNode style: {sld_load_error_msg}",
@@ -448,10 +449,13 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
     ) -> None:
         utils.show_message(self.message_bar, message, level, add_loading_widget)
 
-    def _get_layer_properties_dialog(self, layer):
-        # We use the function syncToLayer of QgsMapLayerConfigWidget
-        # https://qgis.org/pyqgis/3.38/gui/QgsMapLayerConfigWidget.html
-        return self.syncToLayer(layer)
+    def sync_layer_properties(self):
+        # get layer properties dialog
+        # TODO we have to find a more elegant way to retrieve the properties dialog
+        properties_dialog = self.parent().parent().parent().parent().parent().parent()
+
+        # Sync GeoNode's SLD or / and metadata with the layer properties dialog
+        properties_dialog.syncToLayer()
 
     def _toggle_link_controls(self, enabled: bool) -> None:
         self.links_gb.setEnabled(enabled)

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -449,10 +449,26 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
     ) -> None:
         utils.show_message(self.message_bar, message, level, add_loading_widget)
 
+    def find_parent_by_type(self, obj, target_type):
+        # Find the desired object by type
+        # from a structure: self.parent().parent()...
+        current_obj = obj
+        while current_obj is not None:
+            if isinstance(current_obj, target_type):
+                return current_obj
+            if hasattr(current_obj, "parent"):
+                current_obj = current_obj.parent()
+            else:
+                break
+        return None
+
     def sync_layer_properties(self):
         # get layer properties dialog
-        # TODO we have to find a more elegant way to retrieve the properties dialog
-        properties_dialog = self.parent().parent().parent().parent().parent().parent()
+        # We need to find QDialog object from a structure like:
+        # self.parent().parent()...
+        target_type = QtWidgets.QDialog
+        obj = self
+        properties_dialog = self.find_parent_by_type(obj, target_type)
 
         # Sync GeoNode's SLD or / and metadata with the layer properties dialog
         properties_dialog.syncToLayer()

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -468,7 +468,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
         # self.parent().parent()...
         properties_dialog = self.find_parent_by_type(self, QtWidgets.QDialog)
 
-        if properties_dialog != None:
+        if properties_dialog is not None:
             # Sync GeoNode's SLD or / and metadata with the layer properties dialog
             properties_dialog.syncToLayer()
         else:

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -466,9 +466,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
         # get layer properties dialog
         # We need to find QDialog object from a structure like:
         # self.parent().parent()...
-        target_type = QtWidgets.QDialog
-        obj = self
-        properties_dialog = self.find_parent_by_type(obj, target_type)
+        properties_dialog = self.find_parent_by_type(self, QtWidgets.QDialog)
 
         # Sync GeoNode's SLD or / and metadata with the layer properties dialog
         properties_dialog.syncToLayer()

--- a/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
+++ b/src/qgis_geonode/gui/geonode_map_layer_config_widget.py
@@ -314,8 +314,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
         dataset = self.get_dataset()
         updated_metadata = populate_metadata(self.layer.metadata(), dataset)
         self.layer.setMetadata(updated_metadata)
-        layer_properties_dialog = self._get_layer_properties_dialog()
-        layer_properties_dialog.syncToLayer()
+        self._get_layer_properties_dialog(self.layer)
 
     # FIXME: rather use the api_client to perform the metadata upload
     def upload_metadata(self) -> None:
@@ -433,8 +432,7 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
             dataset.default_style.sld, sld_load_error_msg
         )
         if sld_load_result:
-            layer_properties_dialog = self._get_layer_properties_dialog()
-            layer_properties_dialog.syncToLayer()
+            self._get_layer_properties_dialog(self.layer)
         else:
             self._show_message(
                 message=f"Could not load GeoNode style: {sld_load_error_msg}",
@@ -449,10 +447,10 @@ class GeonodeMapLayerConfigWidget(qgis.gui.QgsMapLayerConfigWidget, WidgetUi):
     ) -> None:
         utils.show_message(self.message_bar, message, level, add_loading_widget)
 
-    def _get_layer_properties_dialog(self):
-        # FIXME: This is a very hacky way to get the layer properties dialog
-        #  but I've not been able to find a more elegant way to retrieve it yet
-        return self.parent().parent().parent().parent()
+    def _get_layer_properties_dialog(self, layer):
+        # We use the function syncToLayer of QgsMapLayerConfigWidget
+        # https://qgis.org/pyqgis/3.38/gui/QgsMapLayerConfigWidget.html
+        return self.syncToLayer(layer)
 
     def _toggle_link_controls(self, enabled: bool) -> None:
         self.links_gb.setEnabled(enabled)

--- a/src/qgis_geonode/main.py
+++ b/src/qgis_geonode/main.py
@@ -11,6 +11,7 @@
 
 import os.path
 
+from qgis.core import QgsSettings
 from qgis.gui import QgsGui
 from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication
 from qgis.PyQt.QtGui import QIcon
@@ -35,6 +36,17 @@ class QgisGeoNode:
         locale_path = os.path.join(
             self.plugin_dir, "i18n", "QgisGeoNode_{}.qm".format(locale)
         )
+
+        settings = QgsSettings()
+        help_paths = settings.value("help/helpSearchPath")
+        homepage_root = plugin_metadata.get("homepage_root")
+
+        if isinstance(help_paths, str):
+            help_paths = [homepage_root, help_paths]
+        elif isinstance(help_paths, list):
+            help_paths = [homepage_root] + help_paths
+
+        settings.setValue("help/helpSearchPath", help_paths)
 
         if os.path.exists(locale_path):
             self.translator = QTranslator()

--- a/src/qgis_geonode/main.py
+++ b/src/qgis_geonode/main.py
@@ -43,7 +43,7 @@ class QgisGeoNode:
 
         if isinstance(help_paths, str):
             help_paths = [homepage_root, help_paths]
-        elif isinstance(help_paths, list):
+        elif isinstance(help_paths, list) and not homepage_root in help_paths:
             help_paths = [homepage_root] + help_paths
 
         settings.setValue("help/helpSearchPath", help_paths)


### PR DESCRIPTION
This PR fixes the error of after the reload a default style or metadata from GeoNode in the `layer properties` dialog, reported in the issue #285 
Also, it was implemented a more elegant way to find the QDialog object,  in order using its `syncToLayer` method to synchronize the current changes from the plugin with the layer properties dialog.