### PR TITLE
QGIS crashes during the loading of SLD

### DIFF
--- a/src/qgis_geonode/styles.py
+++ b/src/qgis_geonode/styles.py
@@ -4,6 +4,7 @@ from PyQt5 import QtCore, QtXml
 from qgis.PyQt import QtXml
 
 from . import network
+from .utils import remove_sld_comments
 
 
 def deserialize_sld_doc(
@@ -18,6 +19,11 @@ def deserialize_sld_doc(
     named_layer_element = None
     if sld_loaded:
         root = sld_doc.documentElement()
+
+        # We remove all the comments from the SLD since they cause a QGIS crash
+        # during the SLD serialization (serialize_sld_named_layer, save() method)
+        remove_sld_comments(root)
+
         if not root.isNull():
             sld_named_layer = root.firstChildElement("NamedLayer")
             if not sld_named_layer.isNull():

--- a/src/qgis_geonode/styles.py
+++ b/src/qgis_geonode/styles.py
@@ -4,7 +4,7 @@ from PyQt5 import QtCore, QtXml
 from qgis.PyQt import QtXml
 
 from . import network
-from .utils import remove_sld_comments
+from .utils import remove_comments_from_sld
 
 
 def deserialize_sld_doc(
@@ -22,7 +22,7 @@ def deserialize_sld_doc(
 
         # We remove all the comments from the SLD since they cause a QGIS crash
         # during the SLD serialization (serialize_sld_named_layer, save() method)
-        remove_sld_comments(root)
+        remove_comments_from_sld(root)
 
         if not root.isNull():
             sld_named_layer = root.firstChildElement("NamedLayer")

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -37,3 +37,14 @@ def show_message(
         progress_bar.setMaximum(0)
         message_item.layout().addWidget(progress_bar)
     message_bar.pushWidget(message_item, level=level)
+
+
+def remove_sld_comments(element):
+    child = element.firstChild()
+    while not child.isNull():
+        if child.isComment():
+            element.removeChild(child)
+        else:
+            if child.isElement():
+                remove_sld_comments(child)
+        child = child.nextSibling()

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -39,12 +39,12 @@ def show_message(
     message_bar.pushWidget(message_item, level=level)
 
 
-def remove_sld_comments(element):
+def remove_comments_from_sld(element):
     child = element.firstChild()
     while not child.isNull():
         if child.isComment():
             element.removeChild(child)
         else:
             if child.isElement():
-                remove_sld_comments(child)
+                remove_comments_from_sld(child)
         child = child.nextSibling()


### PR DESCRIPTION
This PR fixes the issue #297 .
It adds a function `remove_comments_from_sld` which remove all the  comments from the retrieved SLD because if the SLD includes comments, QGIS crashes during serialization.