### PR TITLE
Setting the extent of the layer using the defined spatial_extent before adding to the map

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1405,4 +1405,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "ec6b48e320d7faed463d605b6973068d0bb0d17a8c19fa0f8357c0178ac18892"
+content-hash = "8f5db1a121044cd6db04a414cc934a5510b252bc78b0dce4def0f4c4e0b1f112"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ pytest-custom-exit-code = "^0.3.0"
 mypy = "^1.0.0"
 qgis-stubs = "^0.2.0.post1"
 PyQt5-stubs = "^5.15.6.0"
-PyQt5-Qt5 = "5.15.2"
-PyQt5 = "5.15.6"
+PyQt5-Qt5 = {version = "5.15.2", platform = "win32"}
+PyQt5 = {version = "5.15.6", platform = "win32"}
 
 [tool.poetry.dev-dependencies]
 

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -274,6 +274,9 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             self.handle_loading_error
         )
         self.api_client.style_detail_error_received.disconnect(self.handle_style_error)
+
+        # Set the final extent using the defined spatial_extent
+        self.layer.setExtent(self.brief_dataset.spatial_extent)
         self.project.addMapLayer(self.layer)
         self.handle_layer_load_end()
 


### PR DESCRIPTION
This PR solves the issue #299 . When the user was trying to add a layer from a different SRID (e.g EPSG 2100), the final layer extent was set using the coordinates of WGS 84 (EPSG 4326). As a result the layer could not be found by using the `zoom to layer` option.
To solve this issue, I set the layer extent using the `spatial_extent` of the layer (which is well defined) right before the layer is added to the map.