### PR TITLE
[Fixes ISSUE 259] Loading of dataset fails if domain contains geoserver

### DIFF
--- a/src/qgis_geonode/apiclient/geonode_api_v2.py
+++ b/src/qgis_geonode/apiclient/geonode_api_v2.py
@@ -18,9 +18,7 @@ from qgis.PyQt import (
 
 from .. import network
 from .. import styles as geonode_styles
-from ..utils import (
-    log,
-)
+from ..utils import log, url_from_geoserver
 
 from . import models
 from .base import BaseGeonodeClient
@@ -209,9 +207,10 @@ class GeoNodeApiClient(BaseGeonodeClient):
         if auth_provider_name == "basic":
             for service_type, retrieved_url in result.items():
                 try:
-                    prefix, suffix = retrieved_url.partition("geoserver")[::2]
-                    result[service_type] = f"{self.base_url}/gs{suffix}"
-                    log(f"result[service_type]: {self.base_url}/gs{suffix}")
+                    result[service_type] = url_from_geoserver(
+                        self.base_url, retrieved_url
+                    )
+                    log(f"result[service_type]: {result[service_type]}")
                 except AttributeError:
                     pass
         return result
@@ -352,8 +351,7 @@ class GeoNodeApiClient(BaseGeonodeClient):
         sld_url = raw_style.get("sld_url")
         if auth_provider_name == "basic":
             try:
-                prefix, suffix = sld_url.partition("geoserver")[::2]
-                sld_url = f"{self.base_url}/gs{suffix}"
+                sld_url = url_from_geoserver(self.base_url, sld_url)
                 log(f"sld_url: {sld_url}")
             except AttributeError:
                 pass

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -1,4 +1,5 @@
 import typing
+from urllib.parse import urlparse
 
 import qgis.gui
 from PyQt5 import QtCore, QtWidgets
@@ -48,3 +49,16 @@ def remove_comments_from_sld(element):
             if child.isElement():
                 remove_comments_from_sld(child)
         child = child.nextSibling()
+
+
+def url_from_geoserver(base_url: str, raw_url: str):
+
+    # Clean the URL path from trailing and back slashes
+    url_path = urlparse(raw_url).path.strip("/")
+
+    url_path = url_path.split("/")
+    # re-join URL path without the geoserver path
+    suffix = "/".join(url_path[1:])
+    result = f"{base_url}/gs/{suffix}"
+
+    return result

--- a/test/test_apiclient_geonode_api_v2.py
+++ b/test/test_apiclient_geonode_api_v2.py
@@ -295,7 +295,7 @@ def test_apiclient_build_search_filters(
     ],
 )
 def test_url_from_geoserver(geoserver_url, base_url, expected):
-    result = url_from_geoserver(geoserver_Url, base_url)
+    result = url_from_geoserver(geoserver_url, base_url)
     assert result == expected
 
 

--- a/test/test_apiclient_geonode_api_v2.py
+++ b/test/test_apiclient_geonode_api_v2.py
@@ -294,8 +294,8 @@ def test_apiclient_build_search_filters(
         ),
     ],
 )
-def test_url_from_geoserver(geoserver_url, base_url, expected):
-    result = url_from_geoserver(geoserver_url, base_url)
+def test_url_from_geoserver(base_url, geoserver_url, expected):
+    result = url_from_geoserver(base_url, geoserver_url)
     assert result == expected
 
 

--- a/test/test_apiclient_geonode_api_v2.py
+++ b/test/test_apiclient_geonode_api_v2.py
@@ -262,34 +262,34 @@ def test_apiclient_build_search_filters(
 
 
 @pytest.mark.parametrize(
-    "geoserver_url, base_url, expected",
+    "base_url, geoserver_url, expected",
     [
         pytest.param(
-            "http://fake.com/geoserver/ows/",
             "http://fake.com",
+            "http://fake.com/geoserver/ows/",
             "http://fake.com/gs/ows/",
         ),
         pytest.param(
-            "http://fake.com/gs/ows/", "http://fake.com", "http://fake.com/gs/ows/"
+            "http://fake.com", "http://fake.com/gs/ows/", "http://fake.com/gs/ows/"
         ),
         pytest.param(
-            "http://fake.geoserver.com/geoserver/ows/",
             "http://fake.geoserver.com",
+            "http://fake.geoserver.com/geoserver/ows/",
             "http://fake.geoserver.com/gs/ows/",
         ),
         pytest.param(
+            "http://fake.geoserver.com",
             "http://fake.geoserver.com/geoserver/path/to/file.sld",
-            "http://fake.geoserver.com",
             "http://fake.geoserver.com/gs/path/to/file.sld",
         ),
         pytest.param(
-            "http://fake.geoserver.com/gs/path/to/file.sld",
             "http://fake.geoserver.com",
+            "http://fake.geoserver.com/gs/path/to/file.sld",
             "http://fake.geoserver.com/gs/path/to/file.sld",
         ),
         pytest.param(
-            "http://fake.geonode.com/geoserver/path/to/file.sld",
             "http://fake.geonode.com",
+            "http://fake.geonode.com/geoserver/path/to/file.sld",
             "http://fake.geonode.com/gs/path/to/file.sld",
         ),
     ],

--- a/test/test_apiclient_geonode_api_v2.py
+++ b/test/test_apiclient_geonode_api_v2.py
@@ -267,15 +267,15 @@ def test_apiclient_build_search_filters(
         pytest.param(
             "http://fake.com",
             "http://fake.com/geoserver/ows/",
-            "http://fake.com/gs/ows/",
+            "http://fake.com/gs/ows",
         ),
         pytest.param(
-            "http://fake.com", "http://fake.com/gs/ows/", "http://fake.com/gs/ows/"
+            "http://fake.com", "http://fake.com/gs/ows/", "http://fake.com/gs/ows"
         ),
         pytest.param(
             "http://fake.geoserver.com",
             "http://fake.geoserver.com/geoserver/ows/",
-            "http://fake.geoserver.com/gs/ows/",
+            "http://fake.geoserver.com/gs/ows",
         ),
         pytest.param(
             "http://fake.geoserver.com",

--- a/test/test_apiclient_geonode_api_v2.py
+++ b/test/test_apiclient_geonode_api_v2.py
@@ -279,6 +279,11 @@ def test_apiclient_build_search_filters(
         ),
         pytest.param(
             "http://fake.geoserver.com",
+            "http://fake.geoserver.com/geoserver/ows",
+            "http://fake.geoserver.com/gs/ows",
+        ),
+        pytest.param(
+            "http://fake.geoserver.com",
             "http://fake.geoserver.com/geoserver/path/to/file.sld",
             "http://fake.geoserver.com/gs/path/to/file.sld",
         ),


### PR DESCRIPTION
This PR fixes the issue #259 . It includes a function which re-formats the URLs from GeoServer including services (`gs/ows`) and SLD.